### PR TITLE
Add orientation tracking and feedback

### DIFF
--- a/Rocket.cpp
+++ b/Rocket.cpp
@@ -7,6 +7,7 @@ Rocket::Rocket() {
     velocity = 0.0;
     currentStage = 1;
     status = "Idle";
+    orientation = {0.0, 0.0, 0.0};
 }
 
 void Rocket::startLaunch() {
@@ -23,6 +24,11 @@ void Rocket::update(double deltaTime) {
             velocity += 9.8 * deltaTime;  // gravity offset
             altitude += velocity * deltaTime;
             status = "In Flight";
+
+            // Simple attitude control trying to stabilize orientation
+            orientation.pitch *= 0.98;
+            orientation.yaw   *= 0.98;
+            orientation.roll  *= 0.98;
         } else {
             velocity = 0;
             std::cout << "Fuel depleted.\n";
@@ -47,3 +53,11 @@ double Rocket::getFuelLevel() const { return fuelLevel; }
 double Rocket::getAltitude() const { return altitude; }
 double Rocket::getVelocity() const { return velocity; }
 std::string Rocket::getStatus() const { return status; }
+
+void Rocket::setOrientation(const Orientation &ori) {
+    orientation = ori;
+}
+
+Orientation Rocket::getOrientation() const {
+    return orientation;
+}

--- a/Rocket.hpp
+++ b/Rocket.hpp
@@ -2,6 +2,7 @@
 #define ROCKET_HPP
 
 #include <string>
+#include "Telemetry.hpp" // for Orientation struct
 
 class Rocket {
 private:
@@ -10,6 +11,7 @@ private:
     double velocity;          // in m/s
     int currentStage;         // 1 or 2
     std::string status;       // e.g., "Idle", "Launching", "In Flight"
+    Orientation orientation;  // current rocket orientation
 
 public:
     Rocket();
@@ -18,6 +20,10 @@ public:
     void update(double deltaTime);  // simulate flight each second
     void stageSeparation();
     void abortMission();
+
+    // Orientation accessors
+    void setOrientation(const Orientation &ori);
+    Orientation getOrientation() const;
 
     double getFuelLevel() const;
     double getAltitude() const;

--- a/Telemetry.cpp
+++ b/Telemetry.cpp
@@ -1,4 +1,5 @@
 #include "Telemetry.hpp"
+#include "Rocket.hpp"
 #include <cmath>
 #include <cstdlib> // for rand()
 #include <ctime>
@@ -13,7 +14,7 @@ Telemetry::Telemetry() {
     std::srand(std::time(nullptr)); // seed random for small variations
 }
 
-void Telemetry::update(double deltaTime) {
+void Telemetry::update(double deltaTime, Rocket* rocket) {
     // Simulate basic vertical launch acceleration
     acceleration = 30.0 - (altitude / 1000); // throttle back at altitude
     if (acceleration < 5.0) acceleration = 5.0;
@@ -28,6 +29,11 @@ void Telemetry::update(double deltaTime) {
     orientation.pitch += ((rand() % 100 - 50) * 0.01);
     orientation.yaw   += ((rand() % 100 - 50) * 0.01);
     orientation.roll  += ((rand() % 100 - 50) * 0.02);
+
+    // Provide orientation feedback to the rocket if requested
+    if (rocket) {
+        rocket->setOrientation(orientation);
+    }
 }
 
 double Telemetry::getAltitude() const { return altitude; }

--- a/Telemetry.hpp
+++ b/Telemetry.hpp
@@ -7,6 +7,8 @@ struct Orientation {
     double roll;  // Barrel roll angle
 };
 
+class Rocket; // forward declaration
+
 class Telemetry {
 private:
     double altitude;
@@ -18,7 +20,7 @@ private:
 public:
     Telemetry();
 
-    void update(double deltaTime);
+    void update(double deltaTime, Rocket* rocket = nullptr);
 
     double getAltitude() const;
     double getVelocity() const;

--- a/main.cpp
+++ b/main.cpp
@@ -11,14 +11,19 @@ int main() {
     rocket.startLaunch();
 
     for (int i = 0; i < 10; ++i) {
+        // Telemetry provides orientation feedback before rocket update
+        telemetry.update(1.0, &rocket);
         rocket.update(1.0);
-        telemetry.update(1.0);
 
         std::cout << "Time: " << (i + 1) << "s\n";
         std::cout << "Rocket Altitude: " << rocket.getAltitude() << " m\n";
         std::cout << "Rocket Velocity: " << rocket.getVelocity() << " m/s\n";
+        Orientation ori = rocket.getOrientation();
         std::cout << "Telemetry Altitude: " << telemetry.getAltitude() << " m\n";
         std::cout << "Temperature: " << telemetry.getTemperature() << " C\n";
+        std::cout << "Orientation - Pitch: " << ori.pitch
+                  << ", Yaw: " << ori.yaw
+                  << ", Roll: " << ori.roll << "\n";
         std::cout << "------\n";
 
         if (i == 4) {


### PR DESCRIPTION
## Summary
- track rocket orientation with Orientation struct
- propagate telemetry orientation feedback to the rocket
- show orientation info in the main loop

## Testing
- `make`
- `./rocket_sim | head`

------
https://chatgpt.com/codex/tasks/task_e_686816796220832db1419b4b73a2b10a