### PR TITLE
Add UDP telemetry logger with visualization instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX=g++
 CXXFLAGS=-std=c++11 -Wall
 
-SOURCES=main.cpp Rocket.cpp Telemetry.cpp
+SOURCES=main.cpp Rocket.cpp Telemetry.cpp TelemetryLogger.cpp
 OBJECTS=$(SOURCES:.cpp=.o)
 TARGET=rocket_sim
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ Orientation - Pitch: 0.245, Yaw: 0.1666, Roll: -1.0192
 Stage 1 separated. Stage 2 ignition!
 ```
 
+## Real-time Visualization
+
+`rocket_sim` now broadcasts telemetry as JSON UDP packets on port 7000.
+You can connect any visualization tool that understands this simple
+format. The following Python snippet demonstrates how to receive the
+data and print each packet:
+
+```python
+import socket
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.bind(("0.0.0.0", 7000))
+
+while True:
+    data, _ = sock.recvfrom(1024)
+    print(data.decode())
+```
+
+Point your visualization software at `udp://localhost:7000` to display
+altitude, velocity, temperature, and orientation in real time.
+
 ## Future Enhancements
 
 The current simulation uses extremely basic equations. Potential improvements include:

--- a/TelemetryLogger.cpp
+++ b/TelemetryLogger.cpp
@@ -1,0 +1,54 @@
+#include "TelemetryLogger.hpp"
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <cstring>
+#include <iostream>
+
+TelemetryLogger::TelemetryLogger(const std::string& host, int port)
+    : host_(host), port_(port), sockfd_(-1), initialized_(false) {}
+
+TelemetryLogger::~TelemetryLogger() {
+    if (sockfd_ != -1) {
+        close(sockfd_);
+    }
+}
+
+bool TelemetryLogger::initialize() {
+    sockfd_ = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockfd_ < 0) {
+        std::cerr << "Failed to create socket for telemetry" << std::endl;
+        return false;
+    }
+
+    memset(&serverAddr_, 0, sizeof(serverAddr_));
+    serverAddr_.sin_family = AF_INET;
+    serverAddr_.sin_port = htons(port_);
+    if (inet_pton(AF_INET, host_.c_str(), &serverAddr_.sin_addr) <= 0) {
+        std::cerr << "Invalid telemetry host address" << std::endl;
+        return false;
+    }
+
+    initialized_ = true;
+    return true;
+}
+
+void TelemetryLogger::log(double altitude, double velocity,
+                          double temperature, const Orientation& orientation) {
+    if (!initialized_) {
+        if (!initialize()) {
+            return;
+        }
+    }
+
+    char buffer[256];
+    int len = snprintf(buffer, sizeof(buffer),
+                       "{\"altitude\":%.2f,\"velocity\":%.2f,\"temperature\":%.2f,"
+                       "\"pitch\":%.2f,\"yaw\":%.2f,\"roll\":%.2f}\n",
+                       altitude, velocity, temperature,
+                       orientation.pitch, orientation.yaw, orientation.roll);
+    if (len < 0) return;
+
+    sendto(sockfd_, buffer, len, 0,
+           reinterpret_cast<struct sockaddr*>(&serverAddr_), sizeof(serverAddr_));
+}

--- a/TelemetryLogger.hpp
+++ b/TelemetryLogger.hpp
@@ -1,0 +1,25 @@
+#ifndef TELEMETRYLOGGER_HPP
+#define TELEMETRYLOGGER_HPP
+
+#include <string>
+#include <netinet/in.h>
+#include "Telemetry.hpp" // for Orientation struct
+
+class TelemetryLogger {
+public:
+    TelemetryLogger(const std::string& host = "127.0.0.1", int port = 7000);
+    ~TelemetryLogger();
+
+    bool initialize();
+    void log(double altitude, double velocity,
+             double temperature, const Orientation& orientation);
+
+private:
+    std::string host_;
+    int port_;
+    int sockfd_;
+    struct sockaddr_in serverAddr_;
+    bool initialized_;
+};
+
+#endif // TELEMETRYLOGGER_HPP

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,6 @@
 #include "Rocket.hpp"
 #include "Telemetry.hpp"
+#include "TelemetryLogger.hpp"
 #include <iostream>
 #include <thread>
 #include <chrono>
@@ -7,6 +8,7 @@
 int main() {
     Rocket rocket;
     Telemetry telemetry;
+    TelemetryLogger logger;
 
     rocket.startLaunch();
 
@@ -24,6 +26,8 @@ int main() {
         std::cout << "Orientation - Pitch: " << ori.pitch
                   << ", Yaw: " << ori.yaw
                   << ", Roll: " << ori.roll << "\n";
+        logger.log(rocket.getAltitude(), rocket.getVelocity(),
+                    telemetry.getTemperature(), ori);
         std::cout << "------\n";
 
         if (i == 4) {


### PR DESCRIPTION
## Summary
- stream telemetry using new `TelemetryLogger` class
- send altitude, velocity, temperature and orientation every cycle
- compile the new logger
- document how to hook a visualizer to the UDP data

## Testing
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_686952185c00832dac87090c698e27c7