### PR TITLE
Add real-time 3D telemetry viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,23 @@ altitude, velocity, temperature, and orientation in real time. If your tool
 supports it, you can also render the rocket's position and velocity vectors and
 any bodies included in the optional `bodies` array.
 
+### 3D Telemetry Viewer
+
+A small Python script `telemetry_viewer.py` renders the rocket and any celestial bodies in 3D. Build and run `rocket_sim` in one terminal and start the viewer in another:
+
+```bash
+make
+./rocket_sim
+```
+
+In a separate shell run:
+
+```bash
+python3 telemetry_viewer.py
+```
+
+The viewer listens on UDP port 7000 and updates whenever telemetry is received.
+
 ## Future Enhancements
 
 The current simulation uses extremely basic equations. Potential improvements include:

--- a/telemetry_viewer.py
+++ b/telemetry_viewer.py
@@ -1,0 +1,53 @@
+import socket
+import json
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import for 3D
+
+
+def main(host="0.0.0.0", port=7000):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind((host, port))
+
+    plt.ion()
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    ax.set_xlabel("X (m)")
+    ax.set_ylabel("Y (m)")
+    ax.set_zlabel("Z (m)")
+
+    rocket_plot, = ax.plot([0], [0], [0], "ro", label="Rocket")
+    body_plots = {}
+    ax.legend()
+
+    while True:
+        data, _ = sock.recvfrom(65535)
+        try:
+            telem = json.loads(data.decode())
+        except json.JSONDecodeError:
+            continue
+
+        pos = telem.get("position", {})
+        rocket_plot.set_data([pos.get("x", 0)], [pos.get("y", 0)])
+        rocket_plot.set_3d_properties([pos.get("z", 0)])
+
+        for body in telem.get("bodies", []):
+            name = body.get("name", "body")
+            if name not in body_plots:
+                body_plots[name], = ax.plot([body.get("x", 0)],
+                                             [body.get("y", 0)],
+                                             [body.get("z", 0)],
+                                             "bo", label=name)
+                ax.legend()
+            else:
+                plot = body_plots[name]
+                plot.set_data([body.get("x", 0)], [body.get("y", 0)])
+                plot.set_3d_properties([body.get("z", 0)])
+
+        ax.relim()
+        ax.autoscale_view()
+        plt.draw()
+        plt.pause(0.001)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `telemetry_viewer.py` to listen on UDP port 7000 and render rocket & celestial bodies in 3D
- document how to use the viewer alongside `rocket_sim`

## Testing
- `make clean && make`
- `timeout 1 python3 telemetry_viewer.py` (no output expected since no telemetry is sent)
- `pip install matplotlib`

------
https://chatgpt.com/codex/tasks/task_e_687572c168a0832db086a0b7690437c3